### PR TITLE
Show leaderboard position in `/user_stats`

### DIFF
--- a/main.py
+++ b/main.py
@@ -254,11 +254,14 @@ async def user_stats(interaction:discord.Interaction, member: discord.Member = N
         await interaction.response.send_message('You have never counted in this server!')
         conn.close()
         return
-    c.execute('SELECT member_id FROM members ORDER BY score DESC')
+    c.execute(f'SELECT score FROM members WHERE member_id = {member.id}')
+    score = c.fetchone()[0]
+    c.execute(f'SELECT COUNT(member_id) FROM members WHERE score > {score}')
+    position = c.fetchone()[0]
     #leaderboard = c.fetchone()
     #print(leaderboard)
     #position = leaderboard.index(member.id) + 1
-    emb.description = f'{member.mention}\'s stats:\n\n**Score:** {stats[1]}\n**✅Correct:** {stats[2]}\n**❌Wrong:** {stats[3]}\n**Highest valid count:** {stats[4]}\n\n**Correct rate:** {stats[1]/stats[2]*100:.2f}%'
+    emb.description = f'{member.mention}\'s stats:\n\n**Score:** {stats[1]} (#{position})\n**✅Correct:** {stats[2]}\n**❌Wrong:** {stats[3]}\n**Highest valid count:** {stats[4]}\n\n**Correct rate:** {stats[1]/stats[2]*100:.2f}%'
     await interaction.response.send_message(embed=emb)
     conn.close()
 

--- a/main.py
+++ b/main.py
@@ -256,7 +256,7 @@ async def user_stats(interaction:discord.Interaction, member: discord.Member = N
         return
     c.execute(f'SELECT score FROM members WHERE member_id = {member.id}')
     score = c.fetchone()[0]
-    c.execute(f'SELECT COUNT(member_id) FROM members WHERE score > {score}')
+    c.execute(f'SELECT COUNT(member_id) FROM members WHERE score >= {score}')
     position = c.fetchone()[0]
     #leaderboard = c.fetchone()
     #print(leaderboard)


### PR DESCRIPTION
Retrieve the user's score, and then count how many users have a score > that score. Thus, no need to select the entire column from the database. The smaller the data that is selected, the lesser will be the memory overhead.

Please don't hesitate to decline if you would like to take an alternative route.

**Please test before merging! Not tested by me.**
(I mean, I have tested with a dummy database, and it works, but definitely haven't tested as a compiled bot.)