### PR TITLE
Replace `global_name` with `display_name` in `/stats_user` title

### DIFF
--- a/main.py
+++ b/main.py
@@ -256,7 +256,7 @@ async def list_commands(interaction: discord.Interaction):
 async def stats_user(interaction:discord.Interaction, member: discord.Member = None):
     if member is None:
         member = interaction.user
-    emb = discord.Embed(title=f'{member.global_name}\'s stats', color=discord.Color.blue())
+    emb = discord.Embed(title=f'{member.display_name}\'s stats', color=discord.Color.blue())
     conn = sqlite3.connect('database.sqlite3')
     c = conn.cursor()
     c.execute('SELECT * FROM members WHERE member_id = ?', (member.id,))


### PR DESCRIPTION
Currently, in the title of the embed created by the `/stats_user` command, the user's `User.global_name` is being used.

If the user, whose stats we want to get, has not set a global display name/nickname, then `Member.global_name` resolves to `None`, as shown below:

![image](https://github.com/guanciottaman/counting_bot_indently/assets/56736644/384f89f7-746d-4399-85e9-3a58137214ba)

We want the embed's title field to resolve to, in order of priority,
- The user's guild/server display name, if it is different from the global nickname, or
- the global nickname, if it has been set, or
- the username (always available, hence the last fallback option).

This is effectively handled by [`Member.display_name`](https://discordpy.readthedocs.io/en/stable/api.html?highlight=member#discord.Member.display_name).