### PR TITLE
Handle exception when adding failed role if member is no longer in the server

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,8 +188,14 @@ class Bot(commands.Bot):
 
             if not handled_member and self._config.failed_member_id:
                 # Current failed member does not yet have the failed role
-                failed_member: discord.Member = await self.failed_role.guild.fetch_member(self._config.failed_member_id)
-                await failed_member.add_roles(self.failed_role)
+                try:
+                    failed_member: discord.Member = await self.failed_role.guild.fetch_member(self._config.failed_member_id)
+                    await failed_member.add_roles(self.failed_role)
+                except discord.NotFound:
+                    # Member is no longer in the server
+                    self._config.failed_member_id = None
+                    self._config.correct_inputs_by_failed_member = 0
+                    self._config.dump_data()
 
     async def schedule_busy_work(self):
         await asyncio.sleep(5)


### PR DESCRIPTION
It's kind-of a common situation when a troll messes up the count and then leaves the server. In this situation, the method `add_remove_failed_role()` keeps on throwing errors since it cannot get the failed member. Just enclosed that section in `try-except`, and set the `failed_member_id` to `None` if a `discord.NotFound` exception is raised.