### PR TITLE
Show current number instead of next number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+poetry.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ class Bot(commands.Bot):
                     emb.description += (f'\n\n:fire:  Let\'s beat the high score of {self._config.high_score}!  '
                                         f':muscle:\n')
 
-                emb.add_field(name='NEXT number', value=f'{self._config.current_count + 1}', inline=True)
+                emb.add_field(name='CURRENT number', value=f'{self._config.current_count}', inline=True)
 
                 if self._config.current_member_id:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "counting_bot_indently"
+version = "1.0.0"
+description = "Counting bot for the Indently Discord server!"
+authors = ["Guanciottaman <113635544+guanciottaman@users.noreply.github.com>", "Wrichik Basu <56736644+WrichikBasu@users.noreply.github.com>"]
+license = "MIT"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+"discord.py" = "^2.3.2"
+python-dotenv = "^1.0.1"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
We have been showing the next number instead of the current number in the embed that is sent when the bot is restarted. This has been causing confusion, with the chain being broken multiple times because people have the natural tendency to add one to the number shown. I am myself guilty of this quite a number of times.

To fix this, we will now show the current number.

Also added `pyproject.toml` as poetry config.